### PR TITLE
Add SSH Key Auth to hackingBuddyGPT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,14 @@ llm.api_key='your-openai-key'
 log_db.connection_string='log_db.sqlite3'
 
 # exchange with the IP of your target VM
-conn.host='enter-the-private-ip-of-some-vm.local'
-conn.hostname='the-hostname-of-the-vm-used-for-root-detection'
-conn.port=2222
+conn.host='enter IP of AWS Instance'
+conn.hostname='DNS hostname of AWS Instance'
+conn.port=22
 
 # exchange with the user for your target VM
-conn.username='bob'
-conn.password='secret'
+conn.username='username used for AWS Instance'
+conn.password='' #Keep this as is for things to work 
+conn.keyfile='<insert local filepath of ssh key here>'
 
 # which LLM model to use (can be anything openai supports, or if you use a custom llm.api_url, anything your api provides for the model parameter
 llm.model='gpt-3.5-turbo'

--- a/src/hackingBuddyGPT/capabilities/ssh_test_credential.py
+++ b/src/hackingBuddyGPT/capabilities/ssh_test_credential.py
@@ -17,8 +17,8 @@ class SSHTestCredential(Capability):
     def get_name(self):
         return "test_credential"
 
-    def __call__(self, username: str, keyfilename: str, ) -> Tuple[str, bool]:
-        test_conn = self.conn.new_with(username=username, keyfilename=keyfilename)
+    def __call__(self, username: str, password: str, keyfilename: str, ) -> Tuple[str, bool]:
+        test_conn = self.conn.new_with(username=username, password=password,keyfilename=keyfilename)
         try:
             test_conn.init()
             user = test_conn.run("whoami")[0].strip('\n\r ')

--- a/src/hackingBuddyGPT/capabilities/ssh_test_credential.py
+++ b/src/hackingBuddyGPT/capabilities/ssh_test_credential.py
@@ -4,7 +4,7 @@ from typing import Tuple
 import paramiko
 
 from hackingBuddyGPT.utils import SSHConnection
-from .capability import Capability
+from hackingBuddyGPT.capabilities import Capability
 
 
 @dataclass
@@ -17,8 +17,8 @@ class SSHTestCredential(Capability):
     def get_name(self):
         return "test_credential"
 
-    def __call__(self, username: str, password: str) -> Tuple[str, bool]:
-        test_conn = self.conn.new_with(username=username, password=password)
+    def __call__(self, username: str, keyfilename: str, ) -> Tuple[str, bool]:
+        test_conn = self.conn.new_with(username=username, keyfilename=keyfilename)
         try:
             test_conn.init()
             user = test_conn.run("whoami")[0].strip('\n\r ')

--- a/src/hackingBuddyGPT/cli/stats.py
+++ b/src/hackingBuddyGPT/cli/stats.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-from utils.db_storage import DbStorage
+from hackingBuddyGPT.utils.db_storage import DbStorage
 from rich.console import Console
 from rich.table import Table
 

--- a/src/hackingBuddyGPT/utils/ssh_connection/ssh_connection.py
+++ b/src/hackingBuddyGPT/utils/ssh_connection/ssh_connection.py
@@ -12,9 +12,9 @@ class SSHConnection:
     host: str
     hostname: str
     username: str
-    password: str
-    port: int = 22
     keyfilename: str
+    port: int = 22
+    
 
     _conn: Connection = None
 
@@ -22,19 +22,19 @@ class SSHConnection:
         # create the SSH Connection
         conn = Connection(
             f"{self.username}@{self.host}:{self.port}",
-            connect_kwargs={"password": self.password, "key_filename": self.keyfilename, "allow_agent": False},
+            connect_kwargs={ "key_filename": self.keyfilename, "allow_agent": False},
         )
         self._conn = conn
         self._conn.open()
 
-    def new_with(self, *, host=None, hostname=None, username=None, password=None, port=None, keyfilename=None) -> "SSHConnection":
+    def new_with(self, *, host=None, hostname=None, username=None, keyfilename=None, port=None) -> "SSHConnection":
         return SSHConnection(
             host=host or self.host,
             hostname=hostname or self.hostname,
             username=username or self.username,
-            password=password or self.password,
+            keyfilename=keyfilename or self.keyfilename,
             port=port or self.port,
-            keyfilename=keyfilename or self.keyfilename
+            
         )
 
     def run(self, cmd, *args, **kwargs) -> Tuple[str, str, int]:

--- a/src/hackingBuddyGPT/utils/ssh_connection/ssh_connection.py
+++ b/src/hackingBuddyGPT/utils/ssh_connection/ssh_connection.py
@@ -14,6 +14,7 @@ class SSHConnection:
     username: str
     password: str
     port: int = 22
+    keyfilename: str
 
     _conn: Connection = None
 
@@ -21,18 +22,19 @@ class SSHConnection:
         # create the SSH Connection
         conn = Connection(
             f"{self.username}@{self.host}:{self.port}",
-            connect_kwargs={"password": self.password, "look_for_keys": False, "allow_agent": False},
+            connect_kwargs={"password": self.password, "key_filename": self.keyfilename, "allow_agent": False},
         )
         self._conn = conn
         self._conn.open()
 
-    def new_with(self, *, host=None, hostname=None, username=None, password=None, port=None) -> "SSHConnection":
+    def new_with(self, *, host=None, hostname=None, username=None, password=None, port=None, keyfilename=None) -> "SSHConnection":
         return SSHConnection(
             host=host or self.host,
             hostname=hostname or self.hostname,
             username=username or self.username,
             password=password or self.password,
             port=port or self.port,
+            keyfilename=keyfilename or self.keyfilename
         )
 
     def run(self, cmd, *args, **kwargs) -> Tuple[str, str, int]:

--- a/src/hackingBuddyGPT/utils/ssh_connection/ssh_connection.py
+++ b/src/hackingBuddyGPT/utils/ssh_connection/ssh_connection.py
@@ -12,6 +12,7 @@ class SSHConnection:
     host: str
     hostname: str
     username: str
+    password: str
     keyfilename: str
     port: int = 22
     
@@ -22,16 +23,17 @@ class SSHConnection:
         # create the SSH Connection
         conn = Connection(
             f"{self.username}@{self.host}:{self.port}",
-            connect_kwargs={ "key_filename": self.keyfilename, "allow_agent": False},
+            connect_kwargs={"password": self.password, "key_filename": self.keyfilename, "allow_agent": False},
         )
         self._conn = conn
         self._conn.open()
 
-    def new_with(self, *, host=None, hostname=None, username=None, keyfilename=None, port=None) -> "SSHConnection":
+    def new_with(self, *, host=None, hostname=None, username=None, password=None, keyfilename=None, port=None) -> "SSHConnection":
         return SSHConnection(
             host=host or self.host,
             hostname=hostname or self.hostname,
             username=username or self.username,
+            password=password or self.password,
             keyfilename=keyfilename or self.keyfilename,
             port=port or self.port,
             


### PR DESCRIPTION
This project assumes that SSH is always going to be user and password based. However, what if we're wanting to do testing with a third-party instance that does require key-based authentication? My PR hopes to fix that using the Fabric library dependency.